### PR TITLE
PG-1247 add methods to parse unverified tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,12 @@
 # NJWT
+
 JWT library for the Napptive projects
 
 The purpose of this project is to provide a simple JWT library to handle the authentication tokens of the Napptive platform.
 
 ## Usage
+
+To create new tokens:
 
 ```go
      pc := NewAuthxClaim("userID", "username")
@@ -15,9 +18,12 @@ The purpose of this project is to provide a simple JWT library to handle the aut
      recoveredClaim, err := tokenMgr.Recover(*token, secret, &AuthxClaim{})
      recoveredPC, ok := recClaim.PersonalClaim.(*AuthxClaim)
 ```
+
 #### JWT Interceptor
-this interceptor validates a JWT token received
-```
+
+To create an interceptor that validates incoming gRPC calls with a JWT on an authorization header in the context:
+
+```go
 cfg := config.JWTConfig{
    Secret: "mysecret",
    Header: "authorization",
@@ -33,7 +39,7 @@ s = grpc.NewServer(interceptor.WithServerJWTInterceptor(config))
 
 ## License
 
- Copyright 2020 Napptive
+ Copyright 2023 Napptive
 
  Licensed under the Apache License, Version 2.0 (the "License");
  you may not use this file except in compliance with the License.

--- a/pkg/config/jwt_config.go
+++ b/pkg/config/jwt_config.go
@@ -1,6 +1,5 @@
-
 /**
- * Copyright 2020 Napptive
+ * Copyright 2023 Napptive
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -18,12 +17,13 @@
 package config
 
 import (
+	"strings"
+
 	"github.com/napptive/nerrors/pkg/nerrors"
 	"github.com/rs/zerolog/log"
-	"strings"
 )
 
-// JWT with the JWT configuration
+// JWTConfig with the JWT configuration
 type JWTConfig struct {
 	// Secret with the token secret, used to recover the token
 	Secret string
@@ -32,7 +32,7 @@ type JWTConfig struct {
 }
 
 // NewJWTConfig creates a config object with a given secret and header.
-func NewJWTConfig (secret string, header string) JWTConfig {
+func NewJWTConfig(secret string, header string) JWTConfig {
 	return JWTConfig{
 		Secret: secret,
 		Header: header,
@@ -40,7 +40,7 @@ func NewJWTConfig (secret string, header string) JWTConfig {
 }
 
 // IsValid checks if the configuration options are valid.
-func (jc JWTConfig) IsValid () error {
+func (jc JWTConfig) IsValid() error {
 	if jc.Secret == "" {
 		return nerrors.NewInvalidArgumentError("secret must be filled")
 	}
@@ -51,7 +51,7 @@ func (jc JWTConfig) IsValid () error {
 }
 
 // Print the configuration using the application logger.
-func (jc JWTConfig) Print () {
+func (jc JWTConfig) Print() {
 	log.Info().Str("header", jc.Header).
 		Str("secret", strings.Repeat("*", len(jc.Secret))).Msg("Authorization")
 }

--- a/pkg/njwt/claims.go
+++ b/pkg/njwt/claims.go
@@ -114,6 +114,14 @@ type ExtendedAuthxClaim struct {
 	AuthxClaim
 }
 
+// ToClaim transforms an ExtendedAuthxClaim into a standard Claim.
+func (eac *ExtendedAuthxClaim) ToClaim() *Claim {
+	return &Claim{
+		StandardClaims: eac.StandardClaims,
+		PersonalClaim:  eac.AuthxClaim,
+	}
+}
+
 // RefreshClaim is the information stored to create the refresh token.
 type RefreshClaim struct {
 	UserID string

--- a/pkg/njwt/doc.go
+++ b/pkg/njwt/doc.go
@@ -1,0 +1,20 @@
+/**
+ * Copyright 2023 Napptive
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Package njwt provides access to a set of structures and methods related to the creation, validation, and
+// inspection of JWT.
+package njwt
+

--- a/pkg/njwt/token_test.go
+++ b/pkg/njwt/token_test.go
@@ -91,4 +91,26 @@ var _ = ginkgo.Describe("NJWT Token Manager tests", func() {
 
 		})
 	})
+	ginkgo.Context("working with unverified tokens", func() {
+		tokenMgr := New()
+		ginkgo.It("should be able to retrieve raw information from a token", func() {
+			pc := NewAuthxClaim("userID", "username", utils.GetTestAccountId(), utils.GetTestUserName(),
+				utils.GetTestEnvironmentId(), true, "zoneID", "zoneURL")
+			claim := NewClaim("tt", time.Hour, pc)
+
+			secret := "secret"
+			token, err := tokenMgr.Generate(claim, secret)
+			gomega.Expect(err).To(gomega.Succeed())
+			gomega.Expect(token).NotTo(gomega.BeNil())
+
+			personalClaim := &AuthxClaim{}
+			unverifiedClaim, err := tokenMgr.RecoverUnverified(*token, personalClaim)
+			gomega.Expect(err).To(gomega.Succeed())
+			gomega.Expect(unverifiedClaim).ShouldNot(gomega.BeNil())
+			unverifiedAuthClaim := unverifiedClaim.GetAuthxClaim()
+			gomega.Expect(unverifiedAuthClaim).ShouldNot(gomega.BeNil())
+			gomega.Expect(unverifiedAuthClaim).Should(gomega.BeEquivalentTo(pc))
+		})
+
+	})
 })


### PR DESCRIPTION
### Checklist
- [ ] Code compiles correctly
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [ ] Extended the README/documentation, if necessary

#### What does this PR do?

* Add methods to facilitate parsing unverified tokens by clients. In particular the playground-cli will make use of those methods to obtain the zone identifier and URL.
* Minor cleanup

#### Where should the reviewer start?

#### What is missing?

#### How should this be manually tested?

#### Any background context you want to provide?

#### What are the associated tickets?

* PG-1247

#### Screenshots (if appropriate)

#### Questions
